### PR TITLE
Support additional plugins using '--plugin' command line argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,20 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/JoC0de/pre-commit-prettier
+    rev: "v3.3.3"
+    hooks:
+      - id: prettier
+        files: \.(json|xml|html|yaml|yml|js)$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-merge-conflict
+      - id: check-case-conflict
+  - repo: https://github.com/psf/black
+    rev: "24.8.0"
+    hooks:
+      - id: black
+        name: Python formatter (Black)

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,0 +1,30 @@
+﻿# see https://prettier.io/docs/en/options.html
+
+# Specify the line length that the printer will wrap on.
+printWidth: 150
+# Specify the number of spaces per indentation-level.
+tabWidth: 2
+
+endOfLine: "crlf"
+
+# Whitespaces are considered insensitive.
+htmlWhitespaceSensitivity: "ignore"
+
+# Overrides for some file types
+overrides:
+  - files: "*.html"
+
+  - files:
+      - "*.yml"
+      - "*.yaml"
+    options:
+      parser: "yaml"
+      tabWidth: 2
+
+  # no javascript trailing comma as ReSharper complains with
+  # UnsafeCommaInObjectPropertiesList: https://www.jetbrains.com/help/resharper/Reference__Code_Inspections_JAVA_SCRIPT.html#LanguageUsage
+  - files:
+      - "*.js"
+      - "*.html"
+    options:
+      trailingComma: none

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Add this to your `.pre-commit-config.yaml`:
     -   id: prettier
 ```
 
-When using plugins with `prettier` you'll need to declare them under
-`additional_dependencies`. For example:
+When using `prettier` plugins you'll need to declare them under `additional_dependencies`.
+When the plugin name doesn't start with `@prettier/` you need to also add a `--plugin=` argument.
+For example:
 
 ```yaml
 -   repo: https://github.com/JoC0de/pre-commit-prettier
@@ -30,6 +31,9 @@ When using plugins with `prettier` you'll need to declare them under
         additional_dependencies:
         -   prettier@3.3.3
         -   '@prettier/plugin-xml@3.4.1'
+        -   'prettier-plugin-ini@1.2.0'
+        args:
+        -   --plugin=prettier-plugin-ini
 ```
 
 By default, all files are passed to `prettier`, if you want to limit the

--- a/package.json
+++ b/package.json
@@ -1,9 +1,12 @@
 {
-    "name": "pre-commit-prettier",
-    "description": "Wrapper for plugin support for prettier",
-    "version": "1.0.0",
-    "bin": "./run-prettier.js",
-    "main": "./run-prettier.js",
-    "license": "MIT",
-    "type": "module"
+  "name": "pre-commit-prettier",
+  "description": "Wrapper for plugin support for prettier",
+  "version": "1.0.0",
+  "bin": "./run-prettier.js",
+  "main": "./run-prettier.js",
+  "license": "MIT",
+  "type": "module",
+  "files": [
+    "run-prettier.js"
+  ]
 }

--- a/run-prettier.js
+++ b/run-prettier.js
@@ -2,22 +2,51 @@
 
 "use strict";
 
-import { readFileSync, readdirSync } from "node:fs";
+import { readFileSync, readdirSync, existsSync } from "node:fs";
 import path from "node:path";
 import { run as runPrettier } from "prettier/internal/cli.mjs";
 
-const pluginsPath = path.resolve(process.env.NODE_PATH, "@prettier");
+const nodePath = path.resolve(process.env.NODE_PATH);
+const pluginsPath = path.resolve(nodePath, "@prettier");
 
-const plugins = readdirSync(pluginsPath, { withFileTypes: true });
+let plugins = [];
+
+if (existsSync(pluginsPath)) {
+  plugins = readdirSync(pluginsPath, { withFileTypes: true });
+}
+
+// if there is a plugin added using '--plugin=<plugin-name>' command line argument
+// we add them to the plugins list searching them inside the node folder
+for (let argumentIndex = process.argv.length - 1; argumentIndex >= 0; argumentIndex--) {
+  const argument = process.argv[argumentIndex];
+  if (!argument.startsWith("--plugin=")) {
+    continue;
+  }
+
+  const pluginName = argument.slice("--plugin=".length);
+  const matchingDirectories = readdirSync(nodePath, { withFileTypes: true }).filter(
+    (pluginPath) => pluginPath.isDirectory() && pluginPath.name.localeCompare(pluginName, "en", { sensitivity: "base" }) === 0
+  );
+
+  if (matchingDirectories.length === 0) {
+    continue;
+  }
+
+  // consume the command line argument
+  process.argv.splice(argumentIndex, 1);
+
+  plugins.push(
+    ...matchingDirectories.filter((directory) =>
+      plugins.every((existing) => directory.parentPath !== existing.parentPath && directory.name !== existing.name)
+    )
+  );
+}
 
 // neither single nor double quotes are supported around the path.
 const additionalArguments = plugins
   .filter((pluginPath) => pluginPath.isDirectory())
   .flatMap((pluginPath) => {
-    const pluginDirectoryPath = path.join(
-      pluginPath.parentPath,
-      pluginPath.name
-    );
+    const pluginDirectoryPath = path.join(pluginPath.parentPath, pluginPath.name);
     let pluginImportPath;
     try {
       const packageJsonPath = path.join(pluginDirectoryPath, "package.json");
@@ -27,10 +56,7 @@ const additionalArguments = plugins
         if (typeof packageJson.exports["."] === "string") {
           pluginImportPath = path.join(pluginDirectoryPath, packageJson.exports["."]);
         } else if (packageJson.exports["."].default) {
-          pluginImportPath = path.join(
-            pluginDirectoryPath,
-            packageJson.exports["."].default
-          );
+          pluginImportPath = path.join(pluginDirectoryPath, packageJson.exports["."].default);
         }
       }
 
@@ -44,9 +70,7 @@ const additionalArguments = plugins
         pluginImportPath = pluginDirectoryPath;
       }
     } catch (error) {
-      console.error(
-        `Error '${error}' reading or parsing package.json from '${pluginDirectoryPath}'`
-      );
+      console.error(`Error '${error}' reading or parsing package.json from '${pluginDirectoryPath}'`);
       pluginImportPath = pluginDirectoryPath;
     }
     return ["--plugin", pluginImportPath];
@@ -54,5 +78,16 @@ const additionalArguments = plugins
 
 // the first two items of process.argv are reserved (the node.exe and the current file name) so insert after them
 process.argv.splice(2, 0, ...additionalArguments);
+
+// Override stdout.write to filter message that end with "(unchanged)"
+// prettier currently logs messages when a file is not changed we are not interested in them
+const originalWrite = process.stdout.write;
+process.stdout.write = function (message, ...optionalParams) {
+  if (typeof message === "string" && message.includes(" (unchanged)")) {
+    return;
+  }
+
+  originalWrite.apply(process.stdout, [message, ...optionalParams]);
+};
 
 runPrettier();


### PR DESCRIPTION
- allow specifying additional plugins with '--plugin' command line argument
- fix running when no '@prettier' directory exists
- add workaround to remove the '(unchanged)' logs from the output