### PR TITLE
just applying the actual precommit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .vscode
+.idea

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,10 @@
--   id: prettier
-    name: prettier
-    description: ''
-    entry: pre-commit-prettier --write --ignore-unknown
-    language: node
-    'types': [text]
-    args: []
-    require_serial: false
-    additional_dependencies: ["prettier@3.6.2"]
-    minimum_pre_commit_version: '0'
+- id: prettier
+  name: prettier
+  description: ""
+  entry: pre-commit-prettier --write --ignore-unknown
+  language: node
+  "types": [text]
+  args: []
+  require_serial: false
+  additional_dependencies: ["prettier@3.6.2"]
+  minimum_pre_commit_version: "0"


### PR DESCRIPTION
Just apply the actual `pre-commit run --all-files` to reduce diff on the following PRs
Also, it would enable me to develop #5 without needing to wait for approval for each commit to see if the PR is green

cc: @JoC0de 